### PR TITLE
DEVOPS-7641 : Introducing healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM fluent/fluentd:v1.3.1-debian-onbuild
+FROM fluent/fluentd:v1.14.0-debian-1.1
+
+ADD healthcheck.sh /
+USER root
 
 RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev libsystemd-dev python-setuptools python-pip" \
     && apt-get update \
@@ -21,3 +24,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev libsystemd-dev pyt
     && sudo gem sources --clear-all \
     && SUDO_FORCE_REMOVE=yes apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps \
     && rm -rf /var/lib/apt/lists/* /home/fluent/.gem/ruby/2.3.0/cache/*.gem
+
+HEALTHCHECK --interval=60s --timeout=30s --start-period=30s \
+  CMD sh /healthcheck.sh

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+check1=$( cat /fluentd/etc/cache/worker0/storage.json )
+sleep 15
+check2=$( cat /fluentd/etc/cache/worker0/storage.json )
+
+if [ "$check1" = "$check2" ] ; then
+  exit 1 ;
+fi


### PR DESCRIPTION
NOTES for discussion:
* Base image updated since last version is no longer buildable due to dependency issues (see [comment](https://anchorfree.atlassian.net/browse/DEVOPS-7641?focusedCommentId=423189))
* `root` user properly relays our system messages while `fluent` `999:999` does not - might be a testing artifact I encountered or need further base system amends
* 15 sec check timeframe every 60 seconds was enough in VPN servers to detect a fluentd index tracker change. Systems with less syslog load/noise might need different settings?